### PR TITLE
Modernize project to C++20 and add concept-constrained helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,20 @@
 cmake_minimum_required(VERSION 3.17)
 project(random-dungeon-generator)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include_directories(${CMAKE_SOURCE_DIR})
 
 add_executable(random-dungeon-generator main.cpp)
+target_compile_features(random-dungeon-generator PRIVATE cxx_std_20)
 
 enable_testing()
 add_executable(unit-tests tests/test_rdg.cpp)
 add_test(NAME unit-tests COMMAND unit-tests)
 
 target_include_directories(unit-tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_compile_features(unit-tests PRIVATE cxx_std_20)
 target_compile_options(unit-tests PRIVATE -O0 -g --coverage)
 target_link_options(unit-tests PRIVATE --coverage)

--- a/vstd.h
+++ b/vstd.h
@@ -1,14 +1,29 @@
 #pragma once
 
+#include <concepts>
 #include <queue>
 #include <random>
 #include <sstream>
 #include <string>
+#include <utility>
 
 namespace vstd {
 
 template <typename Container, typename Value>
-bool ctn(const Container &container, const Value &value) {
+concept ContainsComparable = requires(const Container &container, const Value &value) {
+    { container.find(value) };
+    { container.end() };
+};
+
+template <typename Queue>
+concept QueueLike = requires(Queue &queue) {
+    { queue.front() };
+    { queue.pop() } -> std::same_as<void>;
+};
+
+template <typename Container, typename Value>
+requires ContainsComparable<Container, Value>
+[[nodiscard]] bool ctn(const Container &container, const Value &value) {
     return container.find(value) != container.end();
 }
 
@@ -40,7 +55,7 @@ std::string str(const T &value) {
     return out.str();
 }
 
-template <typename Queue>
+template <QueueLike Queue>
 auto pop(Queue &queue) {
     auto front = queue.front();
     queue.pop();


### PR DESCRIPTION
### Motivation

- Move the project to a modern C++ standard for cleaner conformance and to enable C++20 features such as concepts.
- Improve type-safety and expressiveness of small utility functions by constraining templates with concepts and marking important returns `[[nodiscard]]`.

### Description

- Update `CMakeLists.txt` to use `C++20`, remove the hardcoded `-std=c++17` flag, disable compiler extensions, and add `target_compile_features(... cxx_std_20)` for both executables.
- Add `<concepts>` and `<utility>` to `vstd.h`, introduce the `ContainsComparable` and `QueueLike` concepts, constrain `ctn(...)` and `pop(...)`, and mark `ctn(...)` as `[[nodiscard]]`.

### Testing

- Configured and built with `cmake -S . -B build` and `cmake --build build -j4` which completed successfully.
- Ran the unit tests with `ctest --test-dir build --output-on-failure` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb63099cc88326b74d7588f273ecdf)