### PR TITLE
Add AGENTS.md note: keep `vstd` updated to latest `main`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 # Agent Notes
 
 - The repository default branch is `main`.
+- `vstd` should always be updated to the latest `main`.


### PR DESCRIPTION
### Motivation
- Make it explicit in the agent guidance that the `vstd` branch must be kept in sync with the repository `main` branch to avoid branch drift.

### Description
- Add a single-line note to `AGENTS.md` stating: "`vstd` should always be updated to the latest `main`."

### Testing
- Documentation-only change; no automated tests were run or required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb63e3d978832681d60b7611abdae0)