### PR TITLE
CMake: switch to C++23, target-scoped includes, warnings and guarded coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,31 @@
 cmake_minimum_required(VERSION 3.17)
 project(random-dungeon-generator)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-include_directories(${CMAKE_SOURCE_DIR})
-
 add_executable(random-dungeon-generator main.cpp)
-target_compile_features(random-dungeon-generator PRIVATE cxx_std_20)
+target_include_directories(random-dungeon-generator PRIVATE ${CMAKE_SOURCE_DIR})
+target_compile_features(random-dungeon-generator PRIVATE cxx_std_23)
+
+add_executable(unit-tests tests/test_rdg.cpp)
+target_include_directories(unit-tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_compile_features(unit-tests PRIVATE cxx_std_23)
+
+foreach(target_name random-dungeon-generator unit-tests)
+  target_compile_options(${target_name} PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic -Wconversion>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->
+  )
+endforeach()
 
 enable_testing()
-add_executable(unit-tests tests/test_rdg.cpp)
 add_test(NAME unit-tests COMMAND unit-tests)
 
-target_include_directories(unit-tests PRIVATE ${CMAKE_SOURCE_DIR})
-target_compile_features(unit-tests PRIVATE cxx_std_20)
-target_compile_options(unit-tests PRIVATE -O0 -g --coverage)
-target_link_options(unit-tests PRIVATE --coverage)
+target_compile_options(unit-tests PRIVATE
+  $<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:GNU,Clang>>:-O0 -g --coverage>
+)
+target_link_options(unit-tests PRIVATE
+  $<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:GNU,Clang>>:--coverage>
+)


### PR DESCRIPTION
### Motivation
- Bump the project C++ baseline to C++23 to enable newer language features and match modern toolchains.
- Replace global include hygiene with target-scoped includes to avoid leaking include paths across targets.
- Enforce stricter warning sets per-compiler to catch portability and correctness issues early.
- Keep coverage instrumentation out of non-test/release builds by scoping it to Debug and specific compilers.

### Description
- Set `CMAKE_CXX_STANDARD` to `23` and update both targets to `cxx_std_23` via `target_compile_features` in `CMakeLists.txt`.
- Remove the global `include_directories(${CMAKE_SOURCE_DIR})` and add `target_include_directories(... PRIVATE ${CMAKE_SOURCE_DIR})` for both `random-dungeon-generator` and `unit-tests`.
- Add strict warning flags using compiler guards in a small loop that applies to both targets: `-Wall -Wextra -Wpedantic -Wconversion` for GNU/Clang and `/W4 /permissive-` for MSVC.
- Restrict coverage flags to the `unit-tests` target and only in Debug builds (and only for GNU/Clang) using generator expressions for `target_compile_options` and `target_link_options`.

### Testing
- Ran `cmake -S . -B build` which configured and generated build files successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb69e174d88326a4016941294780e4)