### PR TITLE
Add const/nodiscard annotations to rdg accessors and update call-sites

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,8 +2,8 @@
 
 int main() {
     auto dungeon = rdg<>::create_dungeon(rdg<>::Options());
-    for (const auto &row:dungeon.getCells()) {
-        for (auto cell:row) {
+    for (const auto &row : dungeon.getCells()) {
+        for (const auto &cell : row) {
             if (cell.hasLabel()) {
                 std::cout << cell.getLabel();
             } else if (cell.hasType(rdg<>::ROOM)) {

--- a/rdg.h
+++ b/rdg.h
@@ -55,31 +55,31 @@ public:
             addType(type);
         }
 
-        bool isBlockedRoom() {
+        [[nodiscard]] bool isBlockedRoom() const {
             return hasType(BLOCKED)
                    || hasType(ROOM);
         }
 
-        bool isBlockedCorridor() {
+        [[nodiscard]] bool isBlockedCorridor() const {
             return hasType(BLOCKED)
                    || hasType(PERIMETER)
                    || hasType(CORRIDOR);
         }
 
-        bool isBlockedDoor() {
+        [[nodiscard]] bool isBlockedDoor() const {
             return hasType(BLOCKED)
                    || isDoorspace();
         }
 
-        bool hasLabel() {
+        [[nodiscard]] bool hasLabel() const {
             return !label.empty();
         }
 
-        std::string getLabel() {
+        [[nodiscard]] const std::string &getLabel() const {
             return label;
         }
 
-        bool isEspace() {
+        [[nodiscard]] bool isEspace() const {
             return hasType(ENTRANCE)
                    || isDoorspace()
                    || hasLabel();
@@ -102,7 +102,7 @@ public:
                    || hasType(CORRIDOR);
         }
 
-        bool isDoorspace() {
+        [[nodiscard]] bool isDoorspace() const {
             return hasType(ARCH)
                    || hasType(DOOR)
                    || hasType(LOCKED)
@@ -111,7 +111,7 @@ public:
                    || hasType(PORTC);
         }
 
-        bool isStairs() {
+        [[nodiscard]] bool isStairs() const {
             return hasType(STAIR_UP)
                    || hasType(STAIR_DN);
         }
@@ -120,7 +120,7 @@ public:
             this->room_id = room_id;
         }
 
-        int getRoomId() {
+        [[nodiscard]] int getRoomId() const {
             return room_id;
         }
 
@@ -208,19 +208,19 @@ public:
         friend Dungeon rdg<T>::create_dungeon(Options options);
 
     public:
-        const auto &getCells() {
+        [[nodiscard]] const auto &getCells() const {
             return cells;
         }
 
-        const auto &getStairs() {
+        [[nodiscard]] const auto &getStairs() const {
             return stairs;
         }
 
-        const auto &getRooms() {
+        [[nodiscard]] const auto &getRooms() const {
             return rooms;
         }
 
-        const auto &getDoors() {
+        [[nodiscard]] const auto &getDoors() const {
             return doors;
         }
 

--- a/tests/test_rdg.cpp
+++ b/tests/test_rdg.cpp
@@ -63,7 +63,7 @@ static void test_generate_default_dungeon() {
     bool has_open_space = false;
     bool has_room_label = false;
     for (const auto &row : cells) {
-        for (auto cell : row) {
+        for (const auto &cell : row) {
             if (cell.isOpenspace()) {
                 has_open_space = true;
             }
@@ -95,7 +95,7 @@ static void test_layout_variants() {
     const auto &cells = dungeon.getCells();
     int open_cells = 0;
     for (const auto &row : cells) {
-        for (auto cell : row) {
+        for (const auto &cell : row) {
             if (cell.isOpenspace() || cell.hasLabel()) {
                 open_cells++;
             }


### PR DESCRIPTION
### Motivation
- Improve const-correctness for read-only accessors and predicates in the dungeon model to prevent accidental mutation and to express intent.
- Make non-owning getters and boolean predicate results `[[nodiscard]]` to surface likely-mistake ignores at call sites.

### Description
- Marked read-only `rdg<T>::Cell` predicate/accessor methods as `const` and added `[[nodiscard]]` to key methods (`isBlockedRoom`, `isBlockedCorridor`, `isBlockedDoor`, `hasLabel`, `getLabel`, `isEspace`, `isDoorspace`, `isStairs`, `getRoomId`) in `rdg.h` and changed `getLabel` to return `const std::string&`.
- Annotated `rdg<T>::Dungeon` accessors (`getCells`, `getStairs`, `getRooms`, `getDoors`) with `const` and `[[nodiscard]]` in `rdg.h`.
- Updated call sites in `main.cpp` and `tests/test_rdg.cpp` to iterate with `const` references to match the new const-correct signatures and avoid extra copies.
- Files changed: `rdg.h`, `main.cpp`, `tests/test_rdg.cpp`.

### Testing
- Ran `cmake -S . -B build` which configured the project successfully.
- Ran `cmake --build build` which completed and produced the executables; compiler warnings unrelated to these changes remain in dungeon generation internals (conversion/misc warnings) but did not block the build.
- Ran `ctest --test-dir build --output-on-failure` and the unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6b002cfc83268e0f046d56510b4a)