### PR TITLE
Iterate rooms by reference in `fix_doors()`

### DIFF
--- a/rdg.h
+++ b/rdg.h
@@ -877,7 +877,7 @@ public:
         void fix_doors() {
             std::set<std::pair<int, int>> fixed;
 
-            for (auto [room_index, room_data]: rooms) {
+            for (auto &[room_index, room_data]: rooms) {
                 std::set<std::string> dirs;
                 for (auto [dir, _]: room_data.door) {
                     dirs.insert(dir);


### PR DESCRIPTION
### Motivation
- Ensure `fix_doors()` mutates each `Room`'s `door` map in-place rather than operating on copies so erase/reinsert and mirrored-door insertions affect the actual entries in `rooms`.

### Description
- Change the structured-binding loop to iterate by reference using `for (auto& [room_index, room_data] : rooms)` so all `room_data.door` erases/inserts operate on the referenced map and mirrored inserts via `rooms[out_id].door.insert(...)` keep the same ownership semantics.

### Testing
- Built and ran tests with `cmake -S . -B build && cmake --build build && ctest --test-dir build`, and the unit test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6b0610ac8326a64acdf5f6d8cac5)