### PR TITLE
Aggressively optimize dungeon generation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,26 +1,31 @@
 #include "rdg.h"
 
 #include <iostream>
+#include <string>
 
 int main() {
     auto dungeon = rdg::create_dungeon(rdg::Options());
+    std::string output;
+    output.reserve(static_cast<std::size_t>(dungeon.rowCount() * ((dungeon.colCount() * 2) + 1)));
+
     for (int row = 0; row < dungeon.rowCount(); ++row) {
         for (int col = 0; col < dungeon.colCount(); ++col) {
             const auto &cell = dungeon.cellAt(row, col);
             if (cell.hasLabel()) {
-                std::cout << cell.getLabel();
+                output.append(cell.getLabel());
             } else if (cell.hasType(rdg::CellType::ROOM)) {
-                std::cout << "X";
+                output.push_back('X');
             } else if (cell.hasType(rdg::CellType::CORRIDOR)) {
-                std::cout << "x";
+                output.push_back('x');
             } else if (cell.isDoorspace()) {
-                std::cout << "D";
+                output.push_back('D');
             } else {
-                std::cout << " ";
+                output.push_back(' ');
             }
-            std::cout << " ";
+            output.push_back(' ');
         }
-        std::cout << '\n';
+        output.push_back('\n');
     }
+    std::cout << output;
     return 0;
 }

--- a/rdg.h
+++ b/rdg.h
@@ -5,10 +5,8 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <optional>
 #include <random>
-#include <set>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -208,26 +206,53 @@ class Cell {
         return static_cast<std::uint16_t>(1u << static_cast<unsigned>(type));
     }
 
+    static constexpr std::uint16_t BLOCKED_BIT =
+            static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::BLOCKED));
+    static constexpr std::uint16_t ROOM_BIT = static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::ROOM));
+    static constexpr std::uint16_t CORRIDOR_BIT =
+            static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::CORRIDOR));
+    static constexpr std::uint16_t PERIMETER_BIT =
+            static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::PERIMETER));
+    static constexpr std::uint16_t ENTRANCE_BIT =
+            static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::ENTRANCE));
+    static constexpr std::uint16_t ARCH_BIT = static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::ARCH));
+    static constexpr std::uint16_t DOOR_BIT = static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::DOOR));
+    static constexpr std::uint16_t LOCKED_BIT =
+            static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::LOCKED));
+    static constexpr std::uint16_t TRAPPED_BIT =
+            static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::TRAPPED));
+    static constexpr std::uint16_t SECRET_BIT =
+            static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::SECRET));
+    static constexpr std::uint16_t PORTC_BIT = static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::PORTC));
+    static constexpr std::uint16_t STAIR_DN_BIT =
+            static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::STAIR_DN));
+    static constexpr std::uint16_t STAIR_UP_BIT =
+            static_cast<std::uint16_t>(1u << static_cast<unsigned>(CellType::STAIR_UP));
+
+    static constexpr std::uint16_t DOORSPACE_BITS =
+            ARCH_BIT | DOOR_BIT | LOCKED_BIT | TRAPPED_BIT | SECRET_BIT | PORTC_BIT;
+    static constexpr std::uint16_t ESPACE_BITS = ENTRANCE_BIT | DOORSPACE_BITS;
+    static constexpr std::uint16_t STAIR_BITS = STAIR_DN_BIT | STAIR_UP_BIT;
+
+    [[nodiscard]] bool hasAny(std::uint16_t mask) const {
+        return (types & mask) != 0;
+    }
+
 public:
     void setType(CellType type) {
-        types = 0;
-        addType(type);
+        types = type_bit(type);
     }
 
     [[nodiscard]] bool isBlockedRoom() const {
-        return hasType(CellType::BLOCKED)
-               || hasType(CellType::ROOM);
+        return hasAny(BLOCKED_BIT | ROOM_BIT);
     }
 
     [[nodiscard]] bool isBlockedCorridor() const {
-        return hasType(CellType::BLOCKED)
-               || hasType(CellType::PERIMETER)
-               || hasType(CellType::CORRIDOR);
+        return hasAny(BLOCKED_BIT | PERIMETER_BIT | CORRIDOR_BIT);
     }
 
     [[nodiscard]] bool isBlockedDoor() const {
-        return hasType(CellType::BLOCKED)
-               || isDoorspace();
+        return hasAny(BLOCKED_BIT | DOORSPACE_BITS);
     }
 
     [[nodiscard]] bool hasLabel() const {
@@ -242,9 +267,7 @@ public:
     }
 
     [[nodiscard]] bool isEspace() const {
-        return hasType(CellType::ENTRANCE)
-               || isDoorspace()
-               || hasLabel();
+        return hasAny(ESPACE_BITS) || hasLabel();
     }
 
     void addType(CellType type) {
@@ -260,22 +283,15 @@ public:
     }
 
     [[nodiscard]] bool isOpenspace() const {
-        return hasType(CellType::ROOM)
-               || hasType(CellType::CORRIDOR);
+        return hasAny(ROOM_BIT | CORRIDOR_BIT);
     }
 
     [[nodiscard]] bool isDoorspace() const {
-        return hasType(CellType::ARCH)
-               || hasType(CellType::DOOR)
-               || hasType(CellType::LOCKED)
-               || hasType(CellType::TRAPPED)
-               || hasType(CellType::SECRET)
-               || hasType(CellType::PORTC);
+        return hasAny(DOORSPACE_BITS);
     }
 
     [[nodiscard]] bool isStairs() const {
-        return hasType(CellType::STAIR_UP)
-               || hasType(CellType::STAIR_DN);
+        return hasAny(STAIR_BITS);
     }
 
     void setRoomId(int room_id) {
@@ -304,31 +320,8 @@ public:
 
     void clearEspace() {
         clearLabel();
-        removeType(CellType::ENTRANCE);
-        removeType(CellType::ARCH);
-        removeType(CellType::DOOR);
-        removeType(CellType::LOCKED);
-        removeType(CellType::TRAPPED);
-        removeType(CellType::SECRET);
-        removeType(CellType::PORTC);
+        types &= static_cast<std::uint16_t>(~ESPACE_BITS);
     }
-};
-
-struct Door;
-
-struct Room {
-    int id = 0;
-    int row = 0;
-    int col = 0;
-    int north = 0;
-    int south = 0;
-    int west = 0;
-    int east = 0;
-    int height = 0;
-    int width = 0;
-    int area = 0;
-
-    std::multimap<Direction, Door> door;
 };
 
 struct Stairs {
@@ -343,16 +336,46 @@ struct Stairs {
     }
 };
 
+struct Door {
+    int row = 0;
+    int col = 0;
+    DoorKind kind = DoorKind::None;
+    int out_id = 0;
+
+    [[nodiscard]] std::string_view getKey() const {
+        return key(kind);
+    }
+
+    [[nodiscard]] std::string_view getType() const {
+        return to_string(kind);
+    }
+};
+
+struct Room {
+    int id = 0;
+    int row = 0;
+    int col = 0;
+    int north = 0;
+    int south = 0;
+    int west = 0;
+    int east = 0;
+    int height = 0;
+    int width = 0;
+    int area = 0;
+
+    std::array<std::vector<Door>, 4> door;
+};
+
 struct Options {
-    int n_rows = 33;  // must be an odd number
-    int n_cols = 33;  // must be an odd number
+    int n_rows = 33; // must be an odd number
+    int n_cols = 33; // must be an odd number
     DungeonLayout dungeon_layout = DungeonLayout::None;
     int room_min = 3; // minimum room size
     int room_max = 9; // maximum room size
     RoomLayout room_layout = RoomLayout::Scattered;
     CorridorLayout corridor_layout = CorridorLayout::LABYRINTH;
     int remove_deadends = 100; // percentage
-    int add_stairs = 2; // number of stairs
+    int add_stairs = 2;        // number of stairs
     MapStyle map_style = MapStyle::Standard;
     int cell_size = 18; // pixels
 };
@@ -386,21 +409,6 @@ struct ValidationError {
     return std::nullopt;
 }
 
-struct Door {
-    int row = 0;
-    int col = 0;
-    DoorKind kind = DoorKind::None;
-    int out_id = 0;
-
-    [[nodiscard]] std::string_view getKey() const {
-        return key(kind);
-    }
-
-    [[nodiscard]] std::string_view getType() const {
-        return to_string(kind);
-    }
-};
-
 class Dungeon;
 
 [[nodiscard]] Dungeon create_dungeon(Options options);
@@ -426,22 +434,14 @@ struct TunnelOffsets {
     std::span<const Offset> next;
 };
 
-inline constexpr std::array<Direction, 4> DIRECTIONS = {
-        Direction::NORTH,
-        Direction::SOUTH,
-        Direction::EAST,
-        Direction::WEST
-};
+inline constexpr std::array<Direction, 4> DIRECTIONS = {Direction::NORTH, Direction::SOUTH, Direction::EAST,
+                                                        Direction::WEST};
 
 inline constexpr std::array<int, 4> DI = {-1, 1, 0, 0};
 inline constexpr std::array<int, 4> DJ = {0, 0, 1, -1};
 
-inline constexpr std::array<Direction, 4> OPPOSITE = {
-        Direction::SOUTH,
-        Direction::NORTH,
-        Direction::WEST,
-        Direction::EAST
-};
+inline constexpr std::array<Direction, 4> OPPOSITE = {Direction::SOUTH, Direction::NORTH, Direction::WEST,
+                                                      Direction::EAST};
 
 [[nodiscard]] constexpr std::size_t direction_index(Direction dir) {
     return static_cast<std::size_t>(dir);
@@ -459,17 +459,9 @@ inline constexpr std::array<Direction, 4> OPPOSITE = {
     return OPPOSITE[direction_index(dir)];
 }
 
-inline constexpr Mask BOX_MASK = {{
-        {{1, 1, 1}},
-        {{1, 0, 1}},
-        {{1, 1, 1}}
-}};
+inline constexpr Mask BOX_MASK = {{{{1, 1, 1}}, {{1, 0, 1}}, {{1, 1, 1}}}};
 
-inline constexpr Mask CROSS_MASK = {{
-        {{0, 1, 0}},
-        {{1, 1, 1}},
-        {{0, 1, 0}}
-}};
+inline constexpr Mask CROSS_MASK = {{{{0, 1, 0}}, {{1, 1, 1}}, {{0, 1, 0}}}};
 
 [[nodiscard]] constexpr const Mask *mask_for(DungeonLayout layout) {
     switch (layout) {
@@ -484,36 +476,30 @@ inline constexpr Mask CROSS_MASK = {{
     return nullptr;
 }
 
-inline constexpr std::array<Offset, 7> STAIR_N_WALLED = {
-        Offset{1, -1}, Offset{0, -1}, Offset{-1, -1}, Offset{-1, 0}, Offset{-1, 1}, Offset{0, 1}, Offset{1, 1}
-};
+inline constexpr std::array<Offset, 7> STAIR_N_WALLED = {Offset{1, -1}, Offset{0, -1}, Offset{-1, -1}, Offset{-1, 0},
+                                                         Offset{-1, 1}, Offset{0, 1},  Offset{1, 1}};
 inline constexpr std::array<Offset, 3> STAIR_N_CORRIDOR = {Offset{0, 0}, Offset{1, 0}, Offset{2, 0}};
 inline constexpr std::array<Offset, 1> STAIR_N_NEXT = {Offset{1, 0}};
 
-inline constexpr std::array<Offset, 7> STAIR_S_WALLED = {
-        Offset{-1, -1}, Offset{0, -1}, Offset{1, -1}, Offset{1, 0}, Offset{1, 1}, Offset{0, 1}, Offset{-1, 1}
-};
+inline constexpr std::array<Offset, 7> STAIR_S_WALLED = {Offset{-1, -1}, Offset{0, -1}, Offset{1, -1}, Offset{1, 0},
+                                                         Offset{1, 1},   Offset{0, 1},  Offset{-1, 1}};
 inline constexpr std::array<Offset, 3> STAIR_S_CORRIDOR = {Offset{0, 0}, Offset{-1, 0}, Offset{-2, 0}};
 inline constexpr std::array<Offset, 1> STAIR_S_NEXT = {Offset{-1, 0}};
 
-inline constexpr std::array<Offset, 7> STAIR_E_WALLED = {
-        Offset{-1, -1}, Offset{-1, 0}, Offset{-1, 1}, Offset{0, 1}, Offset{1, 1}, Offset{1, 0}, Offset{1, -1}
-};
+inline constexpr std::array<Offset, 7> STAIR_E_WALLED = {Offset{-1, -1}, Offset{-1, 0}, Offset{-1, 1}, Offset{0, 1},
+                                                         Offset{1, 1},   Offset{1, 0},  Offset{1, -1}};
 inline constexpr std::array<Offset, 3> STAIR_E_CORRIDOR = {Offset{0, 0}, Offset{0, -1}, Offset{0, -2}};
 inline constexpr std::array<Offset, 1> STAIR_E_NEXT = {Offset{0, -1}};
 
-inline constexpr std::array<Offset, 7> STAIR_W_WALLED = {
-        Offset{-1, 1}, Offset{-1, 0}, Offset{-1, -1}, Offset{0, -1}, Offset{1, -1}, Offset{1, 0}, Offset{1, 1}
-};
+inline constexpr std::array<Offset, 7> STAIR_W_WALLED = {Offset{-1, 1}, Offset{-1, 0}, Offset{-1, -1}, Offset{0, -1},
+                                                         Offset{1, -1}, Offset{1, 0},  Offset{1, 1}};
 inline constexpr std::array<Offset, 3> STAIR_W_CORRIDOR = {Offset{0, 0}, Offset{0, 1}, Offset{0, 2}};
 inline constexpr std::array<Offset, 1> STAIR_W_NEXT = {Offset{0, 1}};
 
-inline constexpr std::array<TunnelOffsets, 4> STAIR_END = {{
-        {STAIR_N_WALLED, STAIR_N_CORRIDOR, STAIR_N_NEXT},
-        {STAIR_S_WALLED, STAIR_S_CORRIDOR, STAIR_S_NEXT},
-        {STAIR_E_WALLED, STAIR_E_CORRIDOR, STAIR_E_NEXT},
-        {STAIR_W_WALLED, STAIR_W_CORRIDOR, STAIR_W_NEXT}
-}};
+inline constexpr std::array<TunnelOffsets, 4> STAIR_END = {{{STAIR_N_WALLED, STAIR_N_CORRIDOR, STAIR_N_NEXT},
+                                                            {STAIR_S_WALLED, STAIR_S_CORRIDOR, STAIR_S_NEXT},
+                                                            {STAIR_E_WALLED, STAIR_E_CORRIDOR, STAIR_E_NEXT},
+                                                            {STAIR_W_WALLED, STAIR_W_CORRIDOR, STAIR_W_NEXT}}};
 
 } // namespace detail
 
@@ -539,11 +525,11 @@ public:
     }
 
     [[nodiscard]] int rowCount() const {
-        return n_rows + 1;
+        return cell_rows;
     }
 
     [[nodiscard]] int colCount() const {
-        return n_cols + 1;
+        return cell_cols;
     }
 
     [[nodiscard]] const Cell &cellAt(int row, int col) const {
@@ -556,20 +542,34 @@ private:
         int j = 0;
     };
 
+    struct TunnelStep {
+        int i = 0;
+        int j = 0;
+        Direction last_dir = Direction::NORTH;
+        bool has_last_dir = false;
+    };
+
     Options options;
     std::mt19937 &rng;
+    std::uint64_t random_state;
     std::vector<Cell> cells;
     std::vector<Room> rooms;
     std::vector<Stairs> stairs;
     std::vector<std::vector<Door>> doors;
     std::vector<std::uint8_t> corridor_degrees;
+    std::vector<std::uint8_t> corridor_links;
     std::vector<std::uint8_t> corridor_node_seen;
     std::vector<CorridorNode> corridor_nodes;
+    std::vector<TunnelStep> tunnel_stack;
+    std::vector<detail::Sill> door_sill_scratch;
+    std::vector<std::size_t> blocked_cells;
 
     const int n_i;
     const int n_j;
     const int n_rows;
     const int n_cols;
+    const int cell_rows;
+    const int cell_cols;
     const int max_row;
     const int max_col;
     const int room_base;
@@ -577,20 +577,26 @@ private:
     int n_rooms = 0;
     int last_room_id = 0;
 
-    explicit Dungeon(Options options, std::mt19937 &rng) :
-            options(std::move(options)),
-            rng(rng),
-            n_i(this->options.n_rows / 2),
-            n_j(this->options.n_cols / 2),
-            n_rows(n_i * 2),
-            n_cols(n_j * 2),
-            max_row(n_rows - 1),
-            max_col(n_cols - 1),
-            room_base((this->options.room_min + 1) / 2),
-            room_radix(((this->options.room_max - this->options.room_min) / 2) + 1) {}
+    explicit Dungeon(Options options, std::mt19937 &rng)
+        : options(std::move(options)), rng(rng), random_state(seed_random_state(rng)), n_i(this->options.n_rows / 2),
+          n_j(this->options.n_cols / 2), n_rows(n_i * 2), n_cols(n_j * 2), cell_rows(n_rows + 1), cell_cols(n_cols + 1),
+          max_row(n_rows - 1), max_col(n_cols - 1), room_base((this->options.room_min + 1) / 2),
+          room_radix(((this->options.room_max - this->options.room_min) / 2) + 1) {
+    }
+
+    [[nodiscard]] static std::uint64_t seed_random_state(std::mt19937 &rng) {
+        const auto high = static_cast<std::uint64_t>(rng()) << 32u;
+        const auto low = static_cast<std::uint64_t>(rng());
+        return high ^ low ^ 0x9E3779B97F4A7C15ull;
+    }
+
+    [[nodiscard]] std::uint32_t random_u32() {
+        random_state = (random_state * 6364136223846793005ull) + 1442695040888963407ull;
+        return static_cast<std::uint32_t>(random_state >> 32u);
+    }
 
     [[nodiscard]] std::size_t index(int row, int col) const {
-        return static_cast<std::size_t>(row * colCount() + col);
+        return static_cast<std::size_t>(row * cell_cols + col);
     }
 
     [[nodiscard]] std::size_t node_index(int i, int j) const {
@@ -633,11 +639,40 @@ private:
         return rooms[static_cast<std::size_t>(id - 1)];
     }
 
+    [[nodiscard]] static constexpr std::uint8_t direction_bit(Direction dir) {
+        return static_cast<std::uint8_t>(1u << detail::direction_index(dir));
+    }
+
+    [[nodiscard]] static Direction first_link_direction(std::uint8_t links) {
+        if (links & direction_bit(Direction::NORTH)) {
+            return Direction::NORTH;
+        }
+        if (links & direction_bit(Direction::SOUTH)) {
+            return Direction::SOUTH;
+        }
+        if (links & direction_bit(Direction::EAST)) {
+            return Direction::EAST;
+        }
+        return Direction::WEST;
+    }
+
+    [[nodiscard]] static CorridorNode corridor_neighbor(CorridorNode node, Direction dir) {
+        return {node.i + detail::dir_i(dir), node.j + detail::dir_j(dir)};
+    }
+
+    void block_cell(int row, int col) {
+        const auto target_index = index(row, col);
+        cells[target_index].setType(CellType::BLOCKED);
+        blocked_cells.push_back(target_index);
+    }
+
     void reset_corridor_graph() {
         corridor_degrees.assign(static_cast<std::size_t>(n_i * n_j), 0);
+        corridor_links.assign(static_cast<std::size_t>(n_i * n_j), 0);
         corridor_node_seen.assign(static_cast<std::size_t>(n_i * n_j), 0);
         corridor_nodes.clear();
         corridor_nodes.reserve(static_cast<std::size_t>(n_i * n_j));
+        tunnel_stack.reserve(static_cast<std::size_t>(n_i * n_j));
     }
 
     void track_corridor_node(CorridorNode node) {
@@ -648,47 +683,51 @@ private:
         }
     }
 
-    void add_corridor_edge(CorridorNode from, CorridorNode to) {
+    void add_corridor_edge(CorridorNode from, CorridorNode to, Direction dir) {
         if (!is_node(from.i, from.j) || !is_node(to.i, to.j)) {
             return;
         }
         track_corridor_node(from);
         track_corridor_node(to);
-        auto &from_degree = corridor_degrees[node_index(from.i, from.j)];
-        auto &to_degree = corridor_degrees[node_index(to.i, to.j)];
+        const auto from_index = node_index(from.i, from.j);
+        const auto to_index = node_index(to.i, to.j);
+        auto &from_degree = corridor_degrees[from_index];
+        auto &to_degree = corridor_degrees[to_index];
         if (from_degree < 255) {
             from_degree++;
         }
         if (to_degree < 255) {
             to_degree++;
         }
+        corridor_links[from_index] |= direction_bit(dir);
+        corridor_links[to_index] |= direction_bit(detail::opposite(dir));
     }
 
     [[nodiscard]] int corridor_degree(CorridorNode node) const {
-        if (!is_node(node.i, node.j)) {
-            return 0;
-        }
         return corridor_degrees[node_index(node.i, node.j)];
+    }
+
+    [[nodiscard]] std::size_t connection_index(int first_room, int second_room) const {
+        const auto low = static_cast<std::size_t>(std::min(first_room, second_room));
+        const auto high = static_cast<std::size_t>(std::max(first_room, second_room));
+        return (low * static_cast<std::size_t>(n_rooms + 1)) + high;
     }
 
     [[nodiscard]] int random_int(int max_exclusive) {
         if (max_exclusive <= 0) {
             return 0;
         }
-        std::uniform_int_distribution<int> dist(0, max_exclusive - 1);
-        return dist(rng);
+        return static_cast<int>(random_u32() % static_cast<std::uint32_t>(max_exclusive));
     }
 
     [[nodiscard]] int random_int(int min_inclusive, int max_inclusive) {
         if (max_inclusive < min_inclusive) {
             return min_inclusive;
         }
-        std::uniform_int_distribution<int> dist(min_inclusive, max_inclusive);
-        return dist(rng);
+        return min_inclusive + random_int((max_inclusive - min_inclusive) + 1);
     }
 
-    template<typename E>
-    [[nodiscard]] E pop_random(std::vector<E> &items) {
+    template <typename E> [[nodiscard]] E pop_random(std::vector<E> &items) {
         auto index = static_cast<std::size_t>(random_int(static_cast<int>(items.size())));
         E value = std::move(items[index]);
         if (index != items.size() - 1) {
@@ -699,7 +738,11 @@ private:
     }
 
     void init_cells() {
-        cells.resize(static_cast<std::size_t>(rowCount() * colCount()));
+        cells.resize(static_cast<std::size_t>(cell_rows * cell_cols));
+        blocked_cells.clear();
+        if (options.dungeon_layout != DungeonLayout::None) {
+            blocked_cells.reserve(cells.size());
+        }
 
         if (const auto *mask = detail::mask_for(options.dungeon_layout)) {
             mask_cells(*mask);
@@ -709,15 +752,15 @@ private:
     }
 
     void mask_cells(const detail::Mask &mask) {
-        const auto r_scale = static_cast<double>(mask.size()) / static_cast<double>(rowCount());
-        const auto c_scale = static_cast<double>(mask.front().size()) / static_cast<double>(colCount());
+        const auto mask_rows = static_cast<int>(mask.size());
+        const auto mask_cols = static_cast<int>(mask.front().size());
 
         for (int r = 0; r < n_rows; r++) {
             for (int c = 0; c < n_cols; c++) {
-                const auto mask_r = static_cast<std::size_t>(static_cast<double>(r) * r_scale);
-                const auto mask_c = static_cast<std::size_t>(static_cast<double>(c) * c_scale);
+                const auto mask_r = static_cast<std::size_t>((r * mask_rows) / cell_rows);
+                const auto mask_c = static_cast<std::size_t>((c * mask_cols) / cell_cols);
                 if (!mask[mask_r][mask_c]) {
-                    cell(r, c).setType(CellType::BLOCKED);
+                    block_cell(r, c);
                 }
             }
         }
@@ -733,7 +776,7 @@ private:
                 const int dr = r - center_r;
                 const int dc = c - center_c;
                 if ((dr * dr) + (dc * dc) > radius_sq) {
-                    cell(r, c).setType(CellType::BLOCKED);
+                    block_cell(r, c);
                 }
             }
         }
@@ -810,25 +853,31 @@ private:
 
         const int h = (r2 - r1) + 1;
         const int w = (c2 - c1) + 1;
-        rooms.push_back({room_id, r1, c1, r1, r2, c1, c2, h, w, h * w, {}});
+        auto &room = rooms.emplace_back();
+        room.id = room_id;
+        room.row = r1;
+        room.col = c1;
+        room.north = r1;
+        room.south = r2;
+        room.west = c1;
+        room.east = c2;
+        room.height = h;
+        room.width = w;
+        room.area = h * w;
 
         for (int r = r1 - 1; r <= r2 + 1; r++) {
-            if (!(cell(r, c1 - 1).hasType(CellType::ROOM)
-                  || cell(r, c1 - 1).hasType(CellType::ENTRANCE))) {
+            if (!(cell(r, c1 - 1).hasType(CellType::ROOM) || cell(r, c1 - 1).hasType(CellType::ENTRANCE))) {
                 cell(r, c1 - 1).addType(CellType::PERIMETER);
             }
-            if (!(cell(r, c2 + 1).hasType(CellType::ROOM)
-                  || cell(r, c2 + 1).hasType(CellType::ENTRANCE))) {
+            if (!(cell(r, c2 + 1).hasType(CellType::ROOM) || cell(r, c2 + 1).hasType(CellType::ENTRANCE))) {
                 cell(r, c2 + 1).addType(CellType::PERIMETER);
             }
         }
         for (int c = c1 - 1; c <= c2 + 1; c++) {
-            if (!(cell(r1 - 1, c).hasType(CellType::ROOM)
-                  || cell(r1 - 1, c).hasType(CellType::ENTRANCE))) {
+            if (!(cell(r1 - 1, c).hasType(CellType::ROOM) || cell(r1 - 1, c).hasType(CellType::ENTRANCE))) {
                 cell(r1 - 1, c).addType(CellType::PERIMETER);
             }
-            if (!(cell(r2 + 1, c).hasType(CellType::ROOM)
-                  || cell(r2 + 1, c).hasType(CellType::ENTRANCE))) {
+            if (!(cell(r2 + 1, c).hasType(CellType::ROOM) || cell(r2 + 1, c).hasType(CellType::ENTRANCE))) {
                 cell(r2 + 1, c).addType(CellType::PERIMETER);
             }
         }
@@ -859,9 +908,7 @@ private:
         }
 
         return std::make_tuple(room_i < 0 ? random_int(n_i - height) : room_i,
-                               room_j < 0 ? random_int(n_j - width) : room_j,
-                               height,
-                               width);
+                               room_j < 0 ? random_int(n_j - width) : room_j, height, width);
     }
 
     [[nodiscard]] std::tuple<bool, bool> sound_room(int r1, int c1, int r2, int c2) const {
@@ -890,8 +937,9 @@ private:
         return dungeon_area / room_area;
     }
 
-    void open_room(Room &room, std::set<std::pair<int, int>> &connected) {
-        auto candidates = door_sills(room);
+    void open_room(Room &room, std::vector<std::uint8_t> &connected) {
+        auto &candidates = door_sill_scratch;
+        door_sills(room, candidates);
         if (candidates.empty()) {
             return;
         }
@@ -910,22 +958,24 @@ private:
 
             const auto out_id = sill.out_id;
             if (out_id) {
-                auto connect = std::make_pair(std::min(room.id, out_id), std::max(room.id, out_id));
+                const auto connect = connection_index(room.id, out_id);
 
-                if (vstd::ctn(connected, connect)) {
+                if (connected[connect]) {
                     n_opens--;
                     continue;
                 }
 
-                connected.insert(connect);
+                connected[connect] = 1;
             }
             const auto open_r = sill.sill_r;
             const auto open_c = sill.sill_c;
             const auto open_dir = sill.dir;
+            const auto open_di = detail::dir_i(open_dir);
+            const auto open_dj = detail::dir_j(open_dir);
 
             for (auto x = 0; x < 3; x++) {
-                const auto r = open_r + (detail::dir_i(open_dir) * x);
-                const auto c = open_c + (detail::dir_j(open_dir) * x);
+                const auto r = open_r + (open_di * x);
+                const auto c = open_c + (open_dj * x);
 
                 cell(r, c).removeType(CellType::PERIMETER);
                 cell(r, c).addType(CellType::ENTRANCE);
@@ -938,7 +988,7 @@ private:
 
             door.out_id = out_id;
             if (out_id) {
-                room.door.insert(std::make_pair(open_dir, door));
+                room.door[detail::direction_index(open_dir)].push_back(door);
             }
         }
     }
@@ -1003,67 +1053,59 @@ private:
         return flumph + random_int(flumph);
     }
 
-    [[nodiscard]] std::optional<detail::Sill> check_sill(int sill_r, int sill_c, Direction dir) const {
-        const auto door_r = sill_r + detail::dir_i(dir);
-        const auto door_c = sill_c + detail::dir_j(dir);
+    void append_sill(int sill_r, int sill_c, Direction dir, std::vector<detail::Sill> &sills) const {
+        const auto di = detail::dir_i(dir);
+        const auto dj = detail::dir_j(dir);
+        const auto door_r = sill_r + di;
+        const auto door_c = sill_c + dj;
         const auto &door_cell = cell(door_r, door_c);
         if (!(door_cell.hasType(CellType::PERIMETER))) {
-            return {};
+            return;
         }
         if (door_cell.isBlockedDoor()) {
-            return {};
+            return;
         }
-        const auto out_r = door_r + detail::dir_i(dir);
-        const auto out_c = door_c + detail::dir_j(dir);
+        const auto out_r = door_r + di;
+        const auto out_c = door_c + dj;
         const auto &out_cell = cell(out_r, out_c);
         if (out_cell.hasType(CellType::BLOCKED)) {
-            return {};
+            return;
         }
         auto out_id = 0;
         if (out_cell.hasType(CellType::ROOM)) {
             out_id = out_cell.getRoomId();
         }
-        return detail::Sill{sill_r, sill_c, dir, door_r, door_c, out_id};
+        sills.push_back({sill_r, sill_c, dir, door_r, door_c, out_id});
     }
 
-    [[nodiscard]] std::vector<detail::Sill> door_sills(const Room &room) const {
-        std::vector<detail::Sill> sills;
-        sills.reserve(static_cast<std::size_t>(
-                ((room.east - room.west) / 2 + 1) * 2
-                + ((room.south - room.north) / 2 + 1) * 2));
+    void door_sills(const Room &room, std::vector<detail::Sill> &sills) const {
+        sills.clear();
+        sills.reserve(static_cast<std::size_t>(((room.east - room.west) / 2 + 1) * 2 +
+                                               ((room.south - room.north) / 2 + 1) * 2));
         if (room.north >= 3) {
             for (int c = room.west; c <= room.east; c += 2) {
-                if (auto sill = check_sill(room.north, c, Direction::NORTH)) {
-                    sills.push_back(sill.value());
-                }
+                append_sill(room.north, c, Direction::NORTH, sills);
             }
         }
         if (room.south <= n_rows - 3) {
             for (int c = room.west; c <= room.east; c += 2) {
-                if (auto sill = check_sill(room.south, c, Direction::SOUTH)) {
-                    sills.push_back(sill.value());
-                }
+                append_sill(room.south, c, Direction::SOUTH, sills);
             }
         }
         if (room.west >= 3) {
             for (int r = room.north; r <= room.south; r += 2) {
-                if (auto sill = check_sill(r, room.west, Direction::WEST)) {
-                    sills.push_back(sill.value());
-                }
+                append_sill(r, room.west, Direction::WEST, sills);
             }
         }
         if (room.east <= n_cols - 3) {
             for (int r = room.north; r <= room.south; r += 2) {
-                if (auto sill = check_sill(r, room.east, Direction::EAST)) {
-                    sills.push_back(sill.value());
-                }
+                append_sill(r, room.east, Direction::EAST, sills);
             }
         }
-        return sills;
     }
 
     void open_rooms() {
-        std::set<std::pair<int, int>> connected;
+        std::vector<std::uint8_t> connected(static_cast<std::size_t>((n_rooms + 1) * (n_rooms + 1)), 0);
         for (int id = 1; id <= n_rooms; id++) {
             open_room(room_by_id(id), connected);
         }
@@ -1071,8 +1113,15 @@ private:
 
     void label_rooms() {
         for (const auto &room: rooms) {
-            auto label = std::to_string(room.id);
-            auto len = label.length();
+            std::array<char, 3> label{};
+            std::size_t len = 0;
+            if (room.id >= 100) {
+                label[len++] = static_cast<char>('0' + (room.id / 100));
+            }
+            if (room.id >= 10) {
+                label[len++] = static_cast<char>('0' + ((room.id / 10) % 10));
+            }
+            label[len++] = static_cast<char>('0' + (room.id % 10));
             const auto label_r = int((room.north + room.south) / 2);
             const auto label_c = int((room.west + room.east - static_cast<int>(len)) / 2) + 1;
 
@@ -1097,16 +1146,9 @@ private:
         }
     }
 
-    struct TunnelStep {
-        int i = 0;
-        int j = 0;
-        Direction last_dir = Direction::NORTH;
-        bool has_last_dir = false;
-    };
-
     void tunnel(int start_i, int start_j, std::optional<Direction> last_dir = std::nullopt) {
-        std::vector<TunnelStep> args;
-        args.reserve(static_cast<std::size_t>(n_i * n_j));
+        auto &args = tunnel_stack;
+        args.clear();
         args.push_back({start_i, start_j, last_dir.value_or(Direction::NORTH), last_dir.has_value()});
         while (!args.empty()) {
             const auto arg = args.back();
@@ -1144,20 +1186,22 @@ private:
     }
 
     [[nodiscard]] bool open_tunnel(int i, int j, Direction dir) {
-        const auto next_i = i + detail::dir_i(dir);
-        const auto next_j = j + detail::dir_j(dir);
+        const auto di = detail::dir_i(dir);
+        const auto dj = detail::dir_j(dir);
+        const auto next_i = i + di;
+        const auto next_j = j + dj;
         const auto this_r = node_row(i);
         const auto this_c = node_col(j);
-        const auto mid_r = this_r + detail::dir_i(dir);
-        const auto mid_c = this_c + detail::dir_j(dir);
-        const auto next_r = this_r + (detail::dir_i(dir) * 2);
-        const auto next_c = this_c + (detail::dir_j(dir) * 2);
+        const auto mid_r = this_r + di;
+        const auto mid_c = this_c + dj;
+        const auto next_r = this_r + (di * 2);
+        const auto next_c = this_c + (dj * 2);
 
         if (sound_tunnel(mid_r, mid_c, next_r, next_c)) {
             carve_corridor_cell(this_r, this_c);
             carve_corridor_cell(mid_r, mid_c);
             carve_corridor_cell(next_r, next_c);
-            add_corridor_edge({i, j}, {next_i, next_j});
+            add_corridor_edge({i, j}, {next_i, next_j}, dir);
             return true;
         }
         return false;
@@ -1170,8 +1214,7 @@ private:
         if (next_c < 0 || next_c > n_cols) {
             return false;
         }
-        return !cell(mid_r, mid_c).isBlockedCorridor()
-               && !cell(next_r, next_c).isBlockedCorridor();
+        return !cell(mid_r, mid_c).isBlockedCorridor() && !cell(next_r, next_c).isBlockedCorridor();
     }
 
     void carve_corridor_cell(int row, int col) {
@@ -1184,6 +1227,7 @@ private:
         if (n <= 0) {
             return;
         }
+        stairs.reserve(static_cast<std::size_t>(n));
         auto candidates = stair_ends();
 
         if (candidates.empty()) {
@@ -1224,6 +1268,10 @@ private:
         return true;
     }
 
+    [[nodiscard]] const detail::TunnelOffsets &stair_end_for_direction(Direction neighbor_direction) const {
+        return detail::STAIR_END[detail::direction_index(detail::opposite(neighbor_direction))];
+    }
+
     [[nodiscard]] std::vector<Stairs> stair_ends() const {
         std::vector<Stairs> candidates;
         candidates.reserve(corridor_nodes.size() / 4);
@@ -1238,35 +1286,31 @@ private:
             if (!cell(r, c).hasType(CellType::CORRIDOR) || cell(r, c).isStairs()) {
                 continue;
             }
-            for (auto dir: detail::DIRECTIONS) {
-                const auto &dir_value = detail::STAIR_END[detail::direction_index(dir)];
-                if (check_tunnel(r, c, dir_value)) {
-                    Stairs end;
-                    end.row = r;
-                    end.col = c;
-
-                    end.next_row = end.row + dir_value.next[0][0];
-                    end.next_col = end.col + dir_value.next[0][1];
-
-                    candidates.push_back(end);
-                    break;
-                }
+            const auto neighbor_direction = sole_corridor_direction(node);
+            if (!neighbor_direction) {
+                continue;
             }
+            const auto &dir_value = stair_end_for_direction(neighbor_direction.value());
+            if (!check_tunnel(r, c, dir_value)) {
+                continue;
+            }
+
+            Stairs end;
+            end.row = r;
+            end.col = c;
+            end.next_row = end.row + dir_value.next[0][0];
+            end.next_col = end.col + dir_value.next[0][1];
+            candidates.push_back(end);
         }
         return candidates;
     }
 
-    [[nodiscard]] std::optional<CorridorNode> sole_corridor_neighbor(CorridorNode node) const {
-        for (auto dir: detail::DIRECTIONS) {
-            CorridorNode neighbor{node.i + detail::dir_i(dir), node.j + detail::dir_j(dir)};
-            if (!is_node(neighbor.i, neighbor.j)) {
-                continue;
-            }
-            if (node_cell(neighbor).hasType(CellType::CORRIDOR)) {
-                return neighbor;
-            }
+    [[nodiscard]] std::optional<Direction> sole_corridor_direction(CorridorNode node) const {
+        const auto links = corridor_links[node_index(node.i, node.j)];
+        if (!links) {
+            return {};
         }
-        return {};
+        return first_link_direction(links);
     }
 
     [[nodiscard]] bool is_dead_end_node(CorridorNode node) const {
@@ -1279,8 +1323,8 @@ private:
             return false;
         }
         if (degree == 1) {
-            const auto neighbor = sole_corridor_neighbor(node);
-            if (neighbor && node_cell(neighbor.value()).isStairs()) {
+            const auto dir = sole_corridor_direction(node);
+            if (dir && node_cell(corridor_neighbor(node, dir.value())).isStairs()) {
                 return false;
             }
         }
@@ -1288,25 +1332,30 @@ private:
     }
 
     [[nodiscard]] std::optional<CorridorNode> collapse_dead_end_node(CorridorNode node) {
-        auto neighbor = sole_corridor_neighbor(node);
+        const auto dir = sole_corridor_direction(node);
+        const auto node_row_value = node_row(node.i);
+        const auto node_col_value = node_col(node.j);
+        const auto node_index_value = node_index(node.i, node.j);
 
-        cell(node_row(node.i), node_col(node.j)).clearTypes();
-        corridor_degrees[node_index(node.i, node.j)] = 0;
+        cell(node_row_value, node_col_value).clearTypes();
+        corridor_degrees[node_index_value] = 0;
+        corridor_links[node_index_value] = 0;
 
-        if (!neighbor) {
+        if (!dir) {
             return {};
         }
 
-        const auto neighbor_row = node_row(neighbor->i);
-        const auto neighbor_col = node_col(neighbor->j);
-        const auto mid_r = (node_row(node.i) + neighbor_row) / 2;
-        const auto mid_c = (node_col(node.j) + neighbor_col) / 2;
+        const auto neighbor = corridor_neighbor(node, dir.value());
+        const auto mid_r = node_row_value + detail::dir_i(dir.value());
+        const auto mid_c = node_col_value + detail::dir_j(dir.value());
         cell(mid_r, mid_c).clearTypes();
 
-        auto &neighbor_degree = corridor_degrees[node_index(neighbor->i, neighbor->j)];
+        const auto neighbor_index = node_index(neighbor.i, neighbor.j);
+        auto &neighbor_degree = corridor_degrees[neighbor_index];
         if (neighbor_degree > 0) {
             neighbor_degree--;
         }
+        corridor_links[neighbor_index] &= static_cast<std::uint8_t>(~direction_bit(detail::opposite(dir.value())));
         return neighbor;
     }
 
@@ -1345,18 +1394,17 @@ private:
     }
 
     void fix_doors() {
-        std::set<std::pair<int, int>> fixed;
+        std::vector<std::uint8_t> fixed(cells.size(), 0);
+        doors.reserve(rooms.size() * detail::DIRECTIONS.size());
 
         for (auto &room_data: rooms) {
-            std::set<Direction> dirs;
-            for (const auto &door_entry: room_data.door) {
-                dirs.insert(door_entry.first);
-            }
-            for (const auto &dir: dirs) {
-                std::vector<Door> shiny;
-                auto range = room_data.door.equal_range(dir);
-                for (auto it = range.first; it != range.second; it++) {
-                    const auto &door = it->second;
+            for (std::size_t dir_index = 0; dir_index < room_data.door.size(); ++dir_index) {
+                auto &dir_doors = room_data.door[dir_index];
+                if (dir_doors.empty()) {
+                    continue;
+                }
+                std::size_t write_index = 0;
+                for (const auto &door: dir_doors) {
                     const auto door_r = door.row;
                     const auto door_c = door.col;
                     const auto &door_cell = cell(door_r, door_c);
@@ -1364,32 +1412,31 @@ private:
                         continue;
                     }
 
-                    if (vstd::ctn(fixed, std::make_pair(door_r, door_c))) {
-                        shiny.push_back(door);
+                    const auto fixed_index = index(door_r, door_c);
+                    if (fixed[fixed_index]) {
+                        dir_doors[write_index++] = door;
                     } else {
                         if (auto out_id = door.out_id) {
-                            const auto out_dir = detail::opposite(dir);
-                            room_by_id(out_id).door.insert(std::make_pair(out_dir, door));
+                            const auto out_dir = detail::opposite(static_cast<Direction>(dir_index));
+                            room_by_id(out_id).door[detail::direction_index(out_dir)].push_back(door);
                         }
-                        shiny.push_back(door);
-                        fixed.insert(std::make_pair(door_r, door_c));
+                        dir_doors[write_index++] = door;
+                        fixed[fixed_index] = 1;
                     }
                 }
-                if (!shiny.empty()) {
-                    room_data.door.erase(dir);
-                    for (const auto &shiny_door: shiny) {
-                        room_data.door.insert(std::make_pair(dir, shiny_door));
-                    }
-                    doors.push_back(std::move(shiny));
+                if (write_index > 0) {
+                    dir_doors.resize(write_index);
+                    doors.push_back(dir_doors);
                 } else {
-                    room_data.door.erase(dir);
+                    dir_doors.clear();
                 }
             }
         }
     }
 
     void empty_blocks() {
-        for (auto &current_cell: cells) {
+        for (const auto target_index: blocked_cells) {
+            auto &current_cell = cells[target_index];
             if (current_cell.hasType(CellType::BLOCKED)) {
                 current_cell.clearTypes();
             }

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -8,8 +8,13 @@ pushd "$BUILD_DIR" >/dev/null
 
 gcov CMakeFiles/unit-tests.dir/tests/test_rdg.cpp.o >/tmp/gcov_rdg_report.txt
 
-coverage_line=$(awk '/File '\''\/workspace\/random-dungeon-generator\/rdg.h'\''/{getline; print; exit}' /tmp/gcov_rdg_report.txt)
+coverage_line=$(awk '/File '\''.*\/rdg.h'\''/{getline; print; exit}' /tmp/gcov_rdg_report.txt)
 coverage_pct=$(echo "$coverage_line" | sed -E 's/Lines executed:([0-9.]+)%.*/\1/')
+
+if [[ -z "$coverage_pct" || "$coverage_pct" == "$coverage_line" ]]; then
+  echo "Coverage FAIL: rdg.h coverage line not found"
+  exit 1
+fi
 
 if awk -v c="$coverage_pct" -v t="$THRESHOLD" 'BEGIN { exit !(c+0 >= t+0) }'; then
   echo "Coverage OK: rdg.h lines executed ${coverage_pct}% (threshold ${THRESHOLD}%)"

--- a/tests/test_rdg.cpp
+++ b/tests/test_rdg.cpp
@@ -1,9 +1,12 @@
 #include "rdg.h"
 
 #include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <random>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 
 static void require(bool condition) {
     if (!condition) {
@@ -24,6 +27,36 @@ static int dungeon_checksum(const rdg::Dungeon &dungeon) {
     checksum += static_cast<int>(dungeon.getRooms().size()) * 17;
     checksum += static_cast<int>(dungeon.getStairs().size()) * 31;
     return checksum;
+}
+
+static rdg::Dungeon create_seeded(rdg::Options options, unsigned seed) {
+    std::mt19937 rng{seed};
+    return rdg::create_dungeon(options, rng);
+}
+
+static int count_cells_with_type(const rdg::Dungeon &dungeon, rdg::CellType type) {
+    int count = 0;
+    for (const auto &cell: dungeon.getCells()) {
+        if (cell.hasType(type)) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static bool has_label(const rdg::Dungeon &dungeon, std::string_view label) {
+    return std::any_of(dungeon.getCells().begin(), dungeon.getCells().end(),
+                       [&](const rdg::Cell &cell) { return cell.getLabel() == label; });
+}
+
+static void require_valid_dungeon(const rdg::Dungeon &dungeon, const rdg::Options &options) {
+    require(static_cast<int>(dungeon.getCells().size()) == options.n_rows * options.n_cols);
+    require(dungeon.rowCount() == options.n_rows);
+    require(dungeon.colCount() == options.n_cols);
+    require(std::all_of(dungeon.getRooms().begin(), dungeon.getRooms().end(), [&](const rdg::Room &room) {
+        return room.id > 0 && room.north <= room.south && room.west <= room.east &&
+               room.area == room.height * room.width;
+    }));
 }
 
 static void test_cell_type_management() {
@@ -48,6 +81,22 @@ static void test_cell_type_management() {
 
     cell.clearTypes();
     require(!cell.hasType(rdg::CellType::ROOM));
+
+    cell.setType(rdg::CellType::BLOCKED);
+    require(cell.isBlockedRoom());
+    require(cell.isBlockedCorridor());
+    require(cell.isBlockedDoor());
+
+    cell.setType(rdg::CellType::PERIMETER);
+    require(cell.isBlockedCorridor());
+
+    for (auto type: {rdg::CellType::ARCH, rdg::CellType::DOOR, rdg::CellType::TRAPPED, rdg::CellType::SECRET,
+                     rdg::CellType::PORTC}) {
+        cell.clearTypes();
+        cell.addType(type);
+        require(cell.isDoorspace());
+        require(cell.isEspace());
+    }
 }
 
 static void test_cell_labels_and_stairs() {
@@ -85,7 +134,7 @@ static void test_generate_default_dungeon() {
 
     bool has_open_space = false;
     bool has_room_label = false;
-    for (const auto &cell : cells) {
+    for (const auto &cell: cells) {
         if (cell.isOpenspace()) {
             has_open_space = true;
         }
@@ -96,6 +145,7 @@ static void test_generate_default_dungeon() {
 
     require(has_open_space);
     require(has_room_label);
+    require(has_label(dungeon, "1"));
     require(!dungeon.getRooms().empty());
 }
 
@@ -115,7 +165,7 @@ static void test_layout_variants() {
 
     const auto &cells = dungeon.getCells();
     int open_cells = 0;
-    for (const auto &cell : cells) {
+    for (const auto &cell: cells) {
         if (cell.isOpenspace() || cell.hasLabel()) {
             open_cells++;
         }
@@ -124,26 +174,195 @@ static void test_layout_variants() {
     require(open_cells > 0);
 }
 
+static void test_generation_option_matrix() {
+    struct Scenario {
+        rdg::DungeonLayout dungeon_layout;
+        rdg::RoomLayout room_layout;
+        rdg::CorridorLayout corridor_layout;
+        int remove_deadends;
+        int add_stairs;
+        unsigned seed;
+    };
+
+    const std::array scenarios{
+            Scenario{rdg::DungeonLayout::None, rdg::RoomLayout::Scattered, rdg::CorridorLayout::LABYRINTH, 0, 0, 11},
+            Scenario{rdg::DungeonLayout::Box, rdg::RoomLayout::Scattered, rdg::CorridorLayout::BENT, 50, 1, 12},
+            Scenario{rdg::DungeonLayout::Cross, rdg::RoomLayout::Packed, rdg::CorridorLayout::STRAIGHT, 100, 2, 13},
+            Scenario{rdg::DungeonLayout::Round, rdg::RoomLayout::Packed, rdg::CorridorLayout::LABYRINTH, 100, 4, 14},
+    };
+
+    for (const auto &scenario: scenarios) {
+        rdg::Options options;
+        options.n_rows = 33;
+        options.n_cols = 33;
+        options.dungeon_layout = scenario.dungeon_layout;
+        options.room_layout = scenario.room_layout;
+        options.corridor_layout = scenario.corridor_layout;
+        options.remove_deadends = scenario.remove_deadends;
+        options.add_stairs = scenario.add_stairs;
+
+        auto dungeon = create_seeded(options, scenario.seed);
+        require_valid_dungeon(dungeon, options);
+        require(!dungeon.getRooms().empty());
+        require(count_cells_with_type(dungeon, rdg::CellType::ROOM) > 0);
+        require(static_cast<int>(dungeon.getStairs().size()) <= options.add_stairs);
+        if (options.add_stairs > 0) {
+            require(!dungeon.getStairs().empty());
+        }
+    }
+}
+
+static void test_generated_door_and_stair_metadata() {
+    rdg::Options options;
+    options.n_rows = 33;
+    options.n_cols = 33;
+    options.add_stairs = 2;
+    options.remove_deadends = 50;
+
+    for (unsigned seed = 1; seed < 100; ++seed) {
+        auto dungeon = create_seeded(options, seed);
+        if (dungeon.getDoors().empty() || dungeon.getStairs().size() != 2) {
+            continue;
+        }
+
+        bool saw_door = false;
+        for (const auto &door_group: dungeon.getDoors()) {
+            require(!door_group.empty());
+            for (const auto &door: door_group) {
+                saw_door = true;
+                require(door.kind != rdg::DoorKind::None);
+                require(!door.getKey().empty());
+                require(!door.getType().empty());
+                require(dungeon.cellAt(door.row, door.col).isDoorspace());
+                require(dungeon.cellAt(door.row, door.col).hasLabel());
+            }
+        }
+        require(saw_door);
+
+        bool saw_down = false;
+        bool saw_up = false;
+        for (const auto &stairs: dungeon.getStairs()) {
+            require(stairs.kind == rdg::StairKind::Down || stairs.kind == rdg::StairKind::Up);
+            require(!stairs.getKey().empty());
+            require(dungeon.cellAt(stairs.row, stairs.col).isStairs());
+            saw_down = saw_down || stairs.kind == rdg::StairKind::Down;
+            saw_up = saw_up || stairs.kind == rdg::StairKind::Up;
+        }
+        require(saw_down);
+        require(saw_up);
+        return;
+    }
+
+    require(false);
+}
+
 static void test_option_helpers() {
     require(rdg::dungeon_layout_from_string("Cross") == rdg::DungeonLayout::Cross);
+    require(rdg::dungeon_layout_from_string("None") == rdg::DungeonLayout::None);
+    require(rdg::dungeon_layout_from_string("Box") == rdg::DungeonLayout::Box);
+    require(rdg::dungeon_layout_from_string("Round") == rdg::DungeonLayout::Round);
+    require(!rdg::dungeon_layout_from_string("bad").has_value());
     require(rdg::room_layout_from_string("Packed") == rdg::RoomLayout::Packed);
+    require(rdg::room_layout_from_string("Scattered") == rdg::RoomLayout::Scattered);
+    require(!rdg::room_layout_from_string("bad").has_value());
     require(rdg::map_style_from_string("Standard") == rdg::MapStyle::Standard);
+    require(!rdg::map_style_from_string("bad").has_value());
+    require(rdg::to_string(rdg::DungeonLayout::None) == "None");
+    require(rdg::to_string(rdg::DungeonLayout::Box) == "Box");
+    require(rdg::to_string(rdg::DungeonLayout::Cross) == "Cross");
     require(rdg::to_string(rdg::DungeonLayout::Round) == "Round");
+    require(rdg::to_string(rdg::RoomLayout::Scattered) == "Scattered");
+    require(rdg::to_string(rdg::RoomLayout::Packed) == "Packed");
+    require(rdg::to_string(rdg::MapStyle::Standard) == "Standard");
 
     rdg::Options options;
     options.n_rows = 20;
     require(rdg::validate_options(options).has_value());
 }
 
-static void test_compact_metadata_helpers() {
-    rdg::Door door;
-    door.kind = rdg::DoorKind::Secret;
-    require(door.getKey() == "secret");
-    require(door.getType() == "Secret Door");
+static void require_validation_error(rdg::Options options, std::string_view expected_message) {
+    const auto validation = rdg::validate_options(options);
+    require(validation.has_value());
+    require(validation->message == expected_message);
 
-    rdg::Stairs stairs;
-    stairs.kind = rdg::StairKind::Up;
-    require(stairs.getKey() == "up");
+    std::mt19937 rng{7};
+    bool threw = false;
+    try {
+        (void)rdg::create_dungeon(options, rng);
+    } catch (const std::invalid_argument &error) {
+        threw = true;
+        require(error.what() == expected_message);
+    }
+    require(threw);
+}
+
+static void test_option_validation_errors() {
+    rdg::Options options;
+
+    auto invalid = options;
+    invalid.n_rows = 1;
+    require_validation_error(invalid, "n_rows and n_cols must both be at least 3");
+
+    invalid = options;
+    invalid.n_cols = 10;
+    require_validation_error(invalid, "n_rows and n_cols must be odd");
+
+    invalid = options;
+    invalid.room_min = 0;
+    require_validation_error(invalid, "room_min and room_max must be positive");
+
+    invalid = options;
+    invalid.room_min = 9;
+    invalid.room_max = 3;
+    require_validation_error(invalid, "room_min must not exceed room_max");
+
+    invalid = options;
+    invalid.remove_deadends = -1;
+    require_validation_error(invalid, "remove_deadends must be between 0 and 100");
+
+    invalid = options;
+    invalid.remove_deadends = 101;
+    require_validation_error(invalid, "remove_deadends must be between 0 and 100");
+
+    invalid = options;
+    invalid.add_stairs = -1;
+    require_validation_error(invalid, "add_stairs must not be negative");
+
+    invalid = options;
+    invalid.cell_size = 0;
+    require_validation_error(invalid, "cell_size must be positive");
+}
+
+static void test_compact_metadata_helpers() {
+    const std::array door_cases{
+            std::pair{rdg::DoorKind::None, std::pair{"", ""}},
+            std::pair{rdg::DoorKind::Arch, std::pair{"arch", "Archway"}},
+            std::pair{rdg::DoorKind::Open, std::pair{"open", "Unlocked Door"}},
+            std::pair{rdg::DoorKind::Locked, std::pair{"lock", "Locked Door"}},
+            std::pair{rdg::DoorKind::Trapped, std::pair{"trap", "Trapped Door"}},
+            std::pair{rdg::DoorKind::Secret, std::pair{"secret", "Secret Door"}},
+            std::pair{rdg::DoorKind::Portcullis, std::pair{"portc", "Portcullis"}},
+    };
+    for (const auto &[kind, expected]: door_cases) {
+        rdg::Door door;
+        door.kind = kind;
+        require(door.getKey() == expected.first);
+        require(door.getType() == expected.second);
+        require(rdg::key(kind) == expected.first);
+        require(rdg::to_string(kind) == expected.second);
+    }
+
+    const std::array stair_cases{
+            std::pair{rdg::StairKind::None, ""},
+            std::pair{rdg::StairKind::Down, "down"},
+            std::pair{rdg::StairKind::Up, "up"},
+    };
+    for (const auto &[kind, expected]: stair_cases) {
+        rdg::Stairs stairs;
+        stairs.kind = kind;
+        require(stairs.getKey() == expected);
+        require(rdg::key(kind) == expected);
+    }
 }
 
 static void test_seeded_rng_is_deterministic() {
@@ -169,7 +388,10 @@ int main() {
     test_cell_labels_and_stairs();
     test_generate_default_dungeon();
     test_layout_variants();
+    test_generation_option_matrix();
+    test_generated_door_and_stair_metadata();
     test_option_helpers();
+    test_option_validation_errors();
     test_compact_metadata_helpers();
     test_seeded_rng_is_deterministic();
     return 0;


### PR DESCRIPTION
## What changed
- Added broader unit coverage for generation options, door/stair metadata, validation errors, and helper conversions.
- Batched CLI output into a single string write.
- Optimized header-only generator hot paths: compact cell bit checks, faster internal PRNG step, flat room-connection tracking, array-backed room doors, reusable door/tunnel scratch storage, corridor link bitmasks, direct stair-end checks, blocked-cell cleanup tracking, and fewer temporary allocations.
- Made the coverage script work from any checkout path.

## Why
- Preserve tested behavior while reducing whole-app and generation hot-path instruction counts.
- Keep the library header-only and avoid new dependencies.

## Validation
- cmake --build build
- ctest --test-dir build --output-on-failure
- cmake --build build-coverage
- ctest --test-dir build-coverage --output-on-failure
- ./scripts/check_coverage.sh build-coverage 95: rdg.h 96.92%
- cmake --build build-release
- ctest --test-dir build-release --output-on-failure
- ./build/random-dungeon-generator
- git diff --check
- Callgrind matrix profile: 37,390,053 Ir baseline -> 25,203,269 Ir final
- Release CLI Callgrind profile: 2,118,371 Ir total, dominated by dynamic loader/runtime startup

## Known limitations / follow-up
- No AVX changes were added; the measured hot paths are branch-heavy graph/grid operations rather than dense vectorizable numeric loops.
- The internal random sequence changed, but unit-tested behavior and deterministic seeded generation are preserved.