### PR TITLE
Fix default dungeon RNG

### DIFF
--- a/rdg.h
+++ b/rdg.h
@@ -1474,7 +1474,8 @@ private:
 }
 
 [[nodiscard]] inline Dungeon create_dungeon(Options options) {
-    return create_dungeon(std::move(options), vstd::rng());
+    static thread_local std::mt19937 rng{std::random_device{}()};
+    return create_dungeon(std::move(options), rng);
 }
 
 } // namespace rdg


### PR DESCRIPTION
## What changed
- Changed the no-argument dungeon factory to use a local std::mt19937 instance.

## Why
The latest parent project includes vstd before RDG, and vstd::rng() returns a different engine type than RDG's seeded overload accepts. This keeps the default factory self-contained while preserving the explicit seeded overload.

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build
- ctest --test-dir build --output-on-failure
- Parent Fall of Nouraajd build, ctest, and python3 test.py passed.